### PR TITLE
Remove py39 and 310 from mypy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Check typing
         run: uv run mypy
+        if: ${{ matrix.python-version == '3.11' }} or ${{ matrix.python-version == '3.12' }}
 
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Removes typechecking for python < 3.11 

reason: tomllib creates type error and ignoring them does not work