### PR TITLE
feat: Provide support for cpu device

### DIFF
--- a/tests/unit/test_core_permanences.py
+++ b/tests/unit/test_core_permanences.py
@@ -11,6 +11,7 @@ from tipi.errors import ProgressNoMatch
 @pytest.fixture
 def mock_torch_cuda():
     with (
+        patch("torch.cuda.is_available", return_value=True),
         patch("torch.cuda.device_count", return_value=2),
         patch("torch.cuda.memory_reserved", side_effect=[100, 200]),
         patch(
@@ -20,9 +21,32 @@ def mock_torch_cuda():
         yield
 
 
-def test_calculate_best_device(mock_torch_cuda):
+@pytest.fixture
+def mock_torch_xpu():
+    with (
+        patch("torch.xpu.is_available", return_value=True),
+        patch("torch.xpu.device_count", return_value=2),
+        patch("torch.xpu.memory_reserved", side_effect=[100, 200]),
+        patch(
+            "torch.xpu.get_device_properties", side_effect=[MagicMock(total_memory=1000), MagicMock(total_memory=1000)]
+        ),
+    ):
+        yield
+
+
+def test_calculate_best_device_no_cuda():
+    device = Device()
+    assert device.device == torch.device("cpu")
+
+
+def test_calculate_best_device_cuda(mock_torch_cuda):
     device = Device()
     assert device.device == torch.device("cuda:0")
+
+
+def test_calculate_best_device_xpu(mock_torch_xpu):
+    device = Device()
+    assert device.device == torch.device("xpu:0")
 
 
 def test_calculate_best_device_vram_usage_error(mock_torch_cuda):

--- a/tipi/core/permanences.py
+++ b/tipi/core/permanences.py
@@ -60,9 +60,40 @@ class Device(Permanence):
         """
         Initializes the instance and calculates the best device for computation.
         """
-        self._calculate_best_device()
+        devices = self._gather_device_statitics()
+        self.device = self._calculate_best_device(devices)
 
-    def _calculate_best_device(self) -> None:
+    def _gather_device_statitics(self) -> list[DeviceWithVRAM]:
+        """Gather device statistics using the official supported Accelerator stats.
+
+        Returns:
+            list[DeviceWithVRAM]: list of DeviceWithVRAM objects containing device and VRAM usage information.
+        """
+        supported_accelerators = [
+            torch.cuda,
+            torch.xpu,
+            # torch.mtia, ## Planned but not implemented yet due to lack of access to hardware
+            # torch.mps, ## Planned but not implemented yet due to lack of access to hardware
+        ]
+
+        devices = []
+
+        for backend in supported_accelerators:
+            if backend.is_available():
+                backend_name = backend.__name__.split(".")[-1]
+                backend_devices = [torch.device(f"{backend_name}:{i}") for i in range(backend.device_count())]
+                devices.extend([
+                    DeviceWithVRAM(
+                        device,
+                        backend.memory_reserved(device) / backend.get_device_properties(device).total_memory,
+                    )
+                    for device in backend_devices
+                ])
+        if not devices:
+            devices.append(DeviceWithVRAM(torch.device("cpu"), 0.0))
+        return devices
+
+    def _calculate_best_device(self, devices: list[DeviceWithVRAM]) -> torch.device:
         """
         Calculate and set the best available CUDA device based on VRAM usage.
 
@@ -76,21 +107,12 @@ class Device(Permanence):
         Attributes:
             device (torch.device): The CUDA device with the lowest VRAM usage.
         """
-        devices = [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
-        vram_usage = [
-            DeviceWithVRAM(
-                device,
-                torch.cuda.memory_reserved(device) / torch.cuda.get_device_properties(device).total_memory,
-            )
-            for device in devices
-        ]
-
-        best_device = min(vram_usage, key=lambda x: x.vram_usage)
+        best_device = min(devices, key=lambda x: x.vram_usage)
 
         if best_device.vram_usage > 0.8:
             raise VRAMUsageError()
 
-        self.device = best_device.device
+        return best_device.device
 
     def cleanup(self) -> None:
         """


### PR DESCRIPTION
previously on cpu only systems the device failed. becaus eat the end an empty list does not provide any device.

New Logic:

- gather all devices first and calculate usage
- if no device selected provide cpu
- addded also support for xpu devices